### PR TITLE
Pass a client name to warning log context in FallbackSnmpClient

### DIFF
--- a/src/Transport/FallbackSnmpClient.php
+++ b/src/Transport/FallbackSnmpClient.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SimPod\PhpSnmp\Transport;
 
 use Psr\Log\LoggerInterface;
+use ReflectionClass;
 use SimPod\PhpSnmp\Exception\GeneralException;
 use SimPod\PhpSnmp\Exception\TimeoutReached;
 
@@ -84,11 +85,12 @@ final class FallbackSnmpClient implements SnmpClient
             try {
                 return $requestCallback($snmpClient);
             } catch (GeneralException | TimeoutReached $exception) {
+                $reflection = new ReflectionClass($snmpClient);
                 $this->logger->warning(
                     'SNMP request failed',
                     [
                         'clientKey' => $key,
-                        'client' => $snmpClient,
+                        'client' => $reflection->getShortName(),
                         'exception' => $exception,
                     ]
                 );

--- a/tests/Transport/FallbackSnmpClientTest.php
+++ b/tests/Transport/FallbackSnmpClientTest.php
@@ -7,6 +7,7 @@ namespace SimPod\PhpSnmp\Tests\Transport;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Psr\Log\Test\TestLogger;
+use ReflectionClass;
 use SimPod\PhpSnmp\Exception\GeneralException;
 use SimPod\PhpSnmp\Exception\TimeoutReached;
 use SimPod\PhpSnmp\Transport\FallbackSnmpClient;
@@ -109,14 +110,14 @@ final class FallbackSnmpClientTest extends TestCase
         self::assertSame('SNMP request failed', $logEntry['message']);
         self::assertSame('warning', $logEntry['level']);
         self::assertSame(0, $logEntry['context']['clientKey']);
-        self::assertSame($client1, $logEntry['context']['client']);
+        self::assertSame((new ReflectionClass($client1))->getShortName(), $logEntry['context']['client']);
         self::assertSame($exception1, $logEntry['context']['exception']);
 
         $logEntry = $logger->records[1];
         self::assertSame('SNMP request failed', $logEntry['message']);
         self::assertSame('warning', $logEntry['level']);
         self::assertSame(1, $logEntry['context']['clientKey']);
-        self::assertSame($client2, $logEntry['context']['client']);
+        self::assertSame((new ReflectionClass($client1))->getShortName(), $logEntry['context']['client']);
         self::assertSame($exception2, $logEntry['context']['exception']);
     }
 


### PR DESCRIPTION
object instance is converted to {} when represented as a string