### PR TITLE
chore(deps): security updates for phpunit and symfony/process

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,10 +82,18 @@ jobs:
                     php-version: ${{ matrix.php-version }}
 
             -   name: Install dependencies
-                run: sudo apt install pipx snmp
+                run: sudo apt install snmp
 
-            -   name: Install snmpsim
-                run: pipx install snmpsim
+            -   name: Install snmpsim via Docker
+                run: |
+                    docker run -d --name snmpsim --network host \
+                      -v "${{ github.workspace }}/tests/Transport/data:/data:ro" \
+                      python:3.10-slim \
+                      bash -c "pip install 'snmpsim==0.4.7' 'pysnmp>=4.4,<5' 'pyasn1<0.5' 'pysmi<0.4' 'pycryptodomex' && rm -rf /usr/local/snmpsim/data && useradd -r -m snmpsim && cp -r /data /home/snmpsim/data && chown -R snmpsim:snmpsim /home/snmpsim && su snmpsim -s /bin/bash -c 'snmpsimd.py --v2c-arch --data-dir=/home/snmpsim/data --agent-udpv4-endpoint 127.0.0.1:15000'"
+                    for i in $(seq 1 60); do
+                      snmpget -v2c -c public -t 1 -r 0 127.0.0.1:15000 .1.3.6.1.2.1.1.3.0 2>/dev/null && break
+                      sleep 2
+                    done
 
             -   name: Cache dependencies installed with composer
                 uses: actions/cache@v4
@@ -98,6 +106,8 @@ jobs:
                 run: COMPOSER_ARGS="--prefer-stable ${{ matrix.dependencies }}" make
 
             -   name: Run tests
+                env:
+                    SNMPSIM_EXTERNAL: "1"
                 run: PHPUNIT_ARGS="--coverage-clover coverage.xml" make test
 
 

--- a/composer.json
+++ b/composer.json
@@ -40,12 +40,12 @@
         "phpstan/phpstan-deprecation-rules": "^1.0.0",
         "phpstan/phpstan-phpunit": "^1.1.0",
         "phpstan/phpstan-strict-rules": "^1.1.0",
-        "phpunit/phpunit": "11.2.3",
+        "phpunit/phpunit": "11.5.50",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^2.0",
         "squizlabs/php_codesniffer": "^4.0",
-        "symfony/process": "7.3.4",
+        "symfony/process": "7.3.11",
         "thecodingmachine/phpstan-safe-rule": "^1.0"
     },
     "autoload": {

--- a/tests/Transport/CliSnmpClientTest.php
+++ b/tests/Transport/CliSnmpClientTest.php
@@ -17,6 +17,7 @@ use SimPod\PhpSnmp\Tests\BaseTestCase;
 use SimPod\PhpSnmp\Transport\Cli\ProcessExecutor;
 use SimPod\PhpSnmp\Transport\CliSnmpClient;
 
+use function getenv;
 use function proc_get_status;
 use function proc_open;
 use function shell_exec;
@@ -37,6 +38,10 @@ final class CliSnmpClientTest extends BaseTestCase
 
     public static function setUpBeforeClass(): void
     {
+        if (getenv('SNMPSIM_EXTERNAL') !== false) {
+            return;
+        }
+
         $command = 'snmpsim-command-responder-lite --v2c-arch --data-dir %s --agent-udpv4-endpoint %s';
         $command = sprintf($command, __DIR__ . '/data', self::SnmpHost);
 

--- a/tests/Transport/ExtensionSnmpClientTest.php
+++ b/tests/Transport/ExtensionSnmpClientTest.php
@@ -14,6 +14,7 @@ use SimPod\PhpSnmp\Exception\TimeoutReached;
 use SimPod\PhpSnmp\Tests\BaseTestCase;
 use SimPod\PhpSnmp\Transport\ExtensionSnmpClient;
 
+use function getenv;
 use function proc_get_status;
 use function proc_open;
 use function shell_exec;
@@ -34,6 +35,10 @@ final class ExtensionSnmpClientTest extends BaseTestCase
 
     public static function setUpBeforeClass(): void
     {
+        if (getenv('SNMPSIM_EXTERNAL') !== false) {
+            return;
+        }
+
         $command = 'snmpsim-command-responder-lite --v2c-arch --data-dir %s --agent-udpv4-endpoint %s';
         $command = sprintf($command, __DIR__ . '/data', self::SnmpHost);
 


### PR DESCRIPTION
## Summary
- Update `phpunit/phpunit` from 11.2.3 to 11.5.50 (security fix)
- Update `symfony/process` from 7.3.4 to 7.3.11 (CVE-2026-24739 — Windows argument escaping)
- Run snmpsim in Docker container (`python:3.10-slim` + etingof snmpsim 0.4.7) to fix CI
- Skip in-process snmpsim startup when `SNMPSIM_EXTERNAL` env is set

## Impact
The `snmpsim` package on PyPI was replaced by lextudio with a broken release. The old etingof packages need Python <3.12 (removed `imp` module). Solution: run snmpsim inside a `python:3.10-slim` Docker container with `--network host`.

Supersedes #110 and #111.