### PR TITLE
chore: require PHP 8.4+ and run CI on 8.4/8.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-24.04
         strategy:
             matrix:
-                php-version: [8.3]
+                php-version: [8.4, 8.5]
         steps:
             -   uses: actions/checkout@v5
             -   uses: shivammathur/setup-php@v2
@@ -40,7 +40,7 @@ jobs:
         runs-on: ubuntu-24.04
         strategy:
             matrix:
-                php-version: [8.3]
+                php-version: [8.4, 8.5]
         steps:
             -   uses: actions/checkout@v5
             -   uses: shivammathur/setup-php@v2
@@ -70,7 +70,7 @@ jobs:
         runs-on: ubuntu-24.04
         strategy:
             matrix:
-                php-version: [8.3, 8.4]
+                php-version: [8.4, 8.5]
                 dependencies: ["", --prefer-lowest]
 
         steps:

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^8.3",
+        "php": "^8.4",
         "psr/log": "^1.1 || ^2 || ^3",
         "thecodingmachine/safe": "^2.1 || ^3"
     },


### PR DESCRIPTION
## Summary
- require PHP 8.4 or newer in composer.json

## Testing
- composer validate --no-check-lock