### PR TITLE
chore: remove psr/log 1 and 2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": "^8.4",
-        "psr/log": "^1.1 || ^2 || ^3",
+        "psr/log": "^3",
         "thecodingmachine/safe": "^2.1 || ^3"
     },
     "suggest": {


### PR DESCRIPTION
## Summary
- require `psr/log` `^3.0`
- drop declared support for `psr/log` v1 and v2